### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 A smart news search MCP (Model Context Protocol) server with **automatic API switching** for reliable news fetching. Never worry about API limits again!
 
+<a href="https://glama.ai/mcp/servers/@guangxiangdebizi/news-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@guangxiangdebizi/news-mcp/badge" alt="News Server MCP server" />
+</a>
+
 ## ✨ Features
 
 - 🔄 **Smart API Switching**: Automatically switches between multiple news APIs when one reaches its limit


### PR DESCRIPTION
This PR adds a badge for the [News MCP Server](https://glama.ai/mcp/servers/@guangxiangdebizi/news-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@guangxiangdebizi/news-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@guangxiangdebizi/news-mcp/badge" alt="News Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.